### PR TITLE
Fixes for core2::io::{Error, Cursor} doctests

### DIFF
--- a/src/io/buffered.rs
+++ b/src/io/buffered.rs
@@ -29,7 +29,7 @@ use core::{cmp, fmt};
 ///
 /// ```no_run
 /// use std::prelude::*;
-/// use bare_io::BufReader;
+/// use core2::io::BufReader;
 /// use std::fs::File;
 ///
 /// fn main() -> core::result::Result<()> {
@@ -56,7 +56,7 @@ impl<R: Read, const S: usize> BufReader<R, S> {
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufReader;
+    /// use core2::io::BufReader;
     /// use std::fs::File;
     ///
     /// fn main() -> core::result::Result<()> {
@@ -83,7 +83,7 @@ impl<R, const S: usize> BufReader<R, S> {
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufReader;
+    /// use core2::io::BufReader;
     /// use std::fs::File;
     ///
     /// fn main() -> core::result::Result<()> {
@@ -105,7 +105,7 @@ impl<R, const S: usize> BufReader<R, S> {
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufReader;
+    /// use core2::io::BufReader;
     /// use std::fs::File;
     ///
     /// fn main() -> core::result::Result<()> {
@@ -177,7 +177,7 @@ impl<R, const S: usize> BufReader<R, S> {
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufReader;
+    /// use core2::io::BufReader;
     /// use std::fs::File;
     ///
     /// fn main() -> core::result::Result<()> {
@@ -339,7 +339,7 @@ impl<R: Seek, const S: usize> Seek for BufReader<R, S> {
 ///
 /// ```no_run
 /// use std::prelude::*;
-/// use bare_io::BufWriter;
+/// use core2::io::BufWriter;
 /// use std::net::TcpStream;
 ///
 /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -374,7 +374,7 @@ pub struct BufWriter<W: Write, const S: usize> {
 /// # Examples
 ///
 /// ```no_run
-/// use bare_io::BufWriter;
+/// use core2::io::BufWriter;
 /// use std::net::TcpStream;
 ///
 /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -404,7 +404,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -503,7 +503,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -522,7 +522,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -539,7 +539,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let buf_writer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -556,7 +556,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let buf_writer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -581,7 +581,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let mut buffer = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -679,7 +679,7 @@ impl<W> IntoInnerError<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -712,7 +712,7 @@ impl<W> IntoInnerError<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// use bare_io::BufWriter;
+    /// use core2::io::BufWriter;
     /// use std::net::TcpStream;
     ///
     /// let mut stream = BufWriter::new(TcpStream::connect("127.0.0.1:34254").unwrap());
@@ -942,7 +942,7 @@ impl<'a, W: Write, const S: usize> Write for LineWriterShim<'a, W, S> {
 /// ```no_run
 /// use std::fs::{self, File};
 /// use std::prelude::*;
-/// use bare_io::LineWriter;
+/// use core2::io::LineWriter;
 ///
 /// fn main() -> core::result::Result<()> {
 ///     let road_not_taken = b"I shall be telling this with a sigh
@@ -992,7 +992,7 @@ impl<W: Write, const S: usize> LineWriter<W, S> {
     ///
     /// ```no_run
     /// use std::fs::File;
-    /// use bare_io::LineWriter;
+    /// use core2::io::LineWriter;
     ///
     /// fn main() -> core::result::Result<()> {
     ///     let file = File::create("poem.txt")?;
@@ -1012,7 +1012,7 @@ impl<W: Write, const S: usize> LineWriter<W, S> {
     ///
     /// ```no_run
     /// use std::fs::File;
-    /// use bare_io::LineWriter;
+    /// use core2::io::LineWriter;
     ///
     /// fn main() -> core::result::Result<()> {
     ///     let file = File::create("poem.txt")?;
@@ -1035,7 +1035,7 @@ impl<W: Write, const S: usize> LineWriter<W, S> {
     ///
     /// ```no_run
     /// use std::fs::File;
-    /// use bare_io::LineWriter;
+    /// use core2::io::LineWriter;
     ///
     /// fn main() -> core::result::Result<()> {
     ///     let file = File::create("poem.txt")?;
@@ -1062,7 +1062,7 @@ impl<W: Write, const S: usize> LineWriter<W, S> {
     ///
     /// ```no_run
     /// use std::fs::File;
-    /// use bare_io::LineWriter;
+    /// use core2::io::LineWriter;
     ///
     /// fn main() -> core::result::Result<()> {
     ///     let file = File::create("poem.txt")?;

--- a/src/io/cursor.rs
+++ b/src/io/cursor.rs
@@ -22,9 +22,9 @@ use core::cmp;
 /// [bytes]: crate::slice
 /// [`File`]: crate::fs::File
 ///
-/// ```no_run
+/// ```
 /// use std::io::prelude::*;
-/// use std::io::{self, SeekFrom};
+/// use core2::io::{self, Seek, SeekFrom, Write};
 /// use std::fs::File;
 ///
 /// // a library function we've written
@@ -39,12 +39,13 @@ use core::cmp;
 ///     Ok(())
 /// }
 ///
+/// # #[cfg(feature = "std")]
 /// # fn foo() -> io::Result<()> {
 /// // Here's some code that uses this library function.
 /// //
 /// // We might want to use a BufReader here for efficiency, but let's
 /// // keep this example focused.
-/// let mut file = File::create("foo.txt")?;
+/// let mut file = File::create("foo.txt").map_err(|e| io::Error::from(e))?;
 ///
 /// write_ten_bytes_at_end(&mut file)?;
 /// # Ok(())
@@ -55,7 +56,7 @@ use core::cmp;
 /// fn test_writes_bytes() {
 ///     // setting up a real File is much slower than an in-memory buffer,
 ///     // let's use a cursor instead
-///     use std::io::Cursor;
+///     use core2::io::Cursor;
 ///     let mut buff = Cursor::new(vec![0; 15]);
 ///
 ///     write_ten_bytes_at_end(&mut buff).unwrap();
@@ -79,7 +80,7 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
+    /// use core2::io::Cursor;
     ///
     /// let buff = Cursor::new(Vec::new());
     /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
@@ -94,7 +95,7 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
+    /// use core2::io::Cursor;
     ///
     /// let buff = Cursor::new(Vec::new());
     /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
@@ -111,7 +112,7 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
+    /// use core2::io::Cursor;
     ///
     /// let buff = Cursor::new(Vec::new());
     /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
@@ -131,7 +132,7 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
+    /// use core2::io::Cursor;
     ///
     /// let mut buff = Cursor::new(Vec::new());
     /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
@@ -148,9 +149,8 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
+    /// use core2::io::{Cursor, Seek, SeekFrom};
     /// use std::io::prelude::*;
-    /// use std::io::SeekFrom;
     ///
     /// let mut buff = Cursor::new(vec![1, 2, 3, 4, 5]);
     ///
@@ -171,7 +171,7 @@ impl<T> Cursor<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::io::Cursor;
+    /// use core2::io::Cursor;
     ///
     /// let mut buff = Cursor::new(vec![1, 2, 3, 4, 5]);
     ///


### PR DESCRIPTION
Adds `From<std::io::Error> for core2::io::Error` and `From<std::io::ErrorKind> for core2::io::ErrorKind` trait impls.

Uses those impls in the doctests when `std` feature is enabled.

Minor name change fixes in `core2/src/io/buffered.rs` for `bare_io -> core2::io`.

Other doctests in `core2/src/io/traits.rs` and elsewhere require implementation of `core2::io` traits for `std` types (not included in this PR).